### PR TITLE
Fixing button name (#25)

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -61,7 +61,7 @@ router.get('/teams/:team/moods', function(req, res, next) {
 });
 
 router.post('/slack-moods', function(req, res, next) {
-  console.log(req.body);
+  // console.log(req.body);
   var mood = new Mood();
   // millisecond precision on the button press is not important, so we are using date now() instead of the event time
   mood.date = Date.now();

--- a/scripts/awesome.team.coffee
+++ b/scripts/awesome.team.coffee
@@ -207,7 +207,10 @@ module.exports = (robot) ->
           msg.send achievement.description
 
   robot.respond /testing/i, (msg) ->
-    buttonName = "mood_" + robot.brain.data._private.team[msg.message.room]
+    # console.log("Room's Team ID: " + robot.brain.data._private.team[msg.message.room]._id)
+    # console.log(robot.brain.data._private.team)
+    # console.log(msg.message.room)
+    buttonName = "mood_" + robot.brain.data._private.team[msg.message.room]._id
     robot.emit 'slack.attachment',
       message: msg.message
       content:


### PR DESCRIPTION
* Adding testing for mood buttons

* Removed user id from Moods schema, made date & moodString required

* Adding logging (temporarily) for /slack-moods

* Commented out logging, corrected creation of button name